### PR TITLE
Add formio-files as nginx entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ spec:
       - backend:
           serviceName: formio-files
           servicePort: 4005
-        path: /files/
+        path: /files/(.*)$
 EOF
 ```
 
@@ -308,7 +308,7 @@ spec:
       - backend:
           serviceName: formio-files
           servicePort: 4005
-        path: /files/
+        path: /files/(.*)$
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -237,10 +237,10 @@ kubectl expose deployment formio-server \
 ```
 # Install Nginx as Ingress Controller
 # You need to configure Helm prior to run the command below: https://docs.microsoft.com/azure/aks/kubernetes-helm
-helm install stable/nginx-ingress \
-    --set controller.replicaCount=2 \
-    --set controller.nodeSelector."beta\.kubernetes\.io/os"=linux \
-    --set defaultBackend.nodeSelector."beta\.kubernetes\.io/os"=linux
+#Make sure you have the latest version of the stable Helm repo, especially since we need the nginx-ingress version > 0.22.0
+helm repo update stable
+# Install Nginx
+helm install stable/nginx-ingress
     
 # Create a dedicated Ingress making the binding between your Service and the this Nginx Ingress Controller
 kubectl apply -f - <<EOF
@@ -253,8 +253,8 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - host: formiodev.<YOUR_DNS>
@@ -290,8 +290,8 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
   - hosts:

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ helm repo update stable
 helm install -n formio-ingress stable/nginx-ingress
     
 # Create a dedicated Ingress making the binding between your Service and the this Nginx Ingress Controller
-kubectl apply -f - <<EOF
+kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -254,7 +254,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
 spec:
   rules:
   - host: formiodev.<YOUR_DNS>
@@ -280,7 +280,7 @@ kubectl create secret tls aks-ingress-tls \
     --cert aks-ingress-tls.crt
 
 # Update the previous Ingress definition by adding the TLS section
-kubectl apply -f - <<EOF
+kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -291,7 +291,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
 spec:
   tls:
   - hosts:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ kubectl expose deployment formio-server \
 #Make sure you have the latest version of the stable Helm repo, especially since we need the nginx-ingress version > 0.22.0
 helm repo update stable
 # Install Nginx
-helm install stable/nginx-ingress
+helm install -n formio-ingress stable/nginx-ingress
     
 # Create a dedicated Ingress making the binding between your Service and the this Nginx Ingress Controller
 kubectl apply -f - <<EOF

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire, x-file-token, range, range-unit"
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: "/$1"
 spec:

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ spec:
           serviceName: formio
           servicePort: 80
         path: /
+      - backend:
+          serviceName: formio-files
+          servicePort: 4005
+        path: /files/
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ spec:
           serviceName: formio
           servicePort: 80
         path: /
+      - backend:
+          serviceName: formio-files
+          servicePort: 4005
+        path: /files/
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ helm repo update stable
 helm install -n formio-ingress stable/nginx-ingress
     
 # Create a dedicated Ingress making the binding between your Service and the this Nginx Ingress Controller
-kubectl create -f - <<EOF
+echo '
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -254,7 +254,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
 spec:
   rules:
   - host: formiodev.<YOUR_DNS>
@@ -268,7 +268,7 @@ spec:
           serviceName: formio-files
           servicePort: 4005
         path: /files/(.*)$
-EOF
+' | kubectl create -f -
 ```
 
 ## Setup HTTPS
@@ -280,7 +280,7 @@ kubectl create secret tls aks-ingress-tls \
     --cert aks-ingress-tls.crt
 
 # Update the previous Ingress definition by adding the TLS section
-kubectl create -f - <<EOF
+echo '
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -291,7 +291,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
 spec:
   tls:
   - hosts:
@@ -309,7 +309,7 @@ spec:
           serviceName: formio-files
           servicePort: 4005
         path: /files/(.*)$
-EOF
+' | kubectl apply -f -
 ```
 
 You could now test this setup by following those instructions: https://docs.microsoft.com/azure/aks/ingress-own-tls#test-the-ingress-configuration

--- a/README.md
+++ b/README.md
@@ -257,13 +257,13 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: "/$1"
 spec:
   rules:
-  - host: formiodev.<YOUR_DNS>
+  - host: formio<YOUR_DNS>
     http:
       paths:
       - backend:
           serviceName: formio
           servicePort: 80
-        path: /
+        path: /(.*)$
       - backend:
           serviceName: formio-files
           servicePort: 4005
@@ -284,27 +284,27 @@ echo '
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: formiodev
+  name: formio
   annotations: 
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "content-type, cache-control, pragma, x-remote-token, x-allow, x-expire, x-file-token, range, range-unit"
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: "/$1"
 spec:
   tls:
   - hosts:
-    - formiodev.<YOUR_DNS>
+    - formio<YOUR_DNS>
     secretName: aks-ingress-tls
   rules:
-  - host: formiodev.<YOUR_DNS>
+  - host: formio<YOUR_DNS>
     http:
       paths:
       - backend:
           serviceName: formio
           servicePort: 80
-        path: /
+        path: /(.*)$
       - backend:
           serviceName: formio-files
           servicePort: 4005


### PR DESCRIPTION
Complete the setup to have both `api-server` and `pdf-server` paths in nginx ingress controller: https://help.form.io/tutorials/deployment/azure/#nginx-setup

- https://stackoverflow.com/questions/58839056/nginx-routing-ignores-anything-after-path-rule
- https://stackoverflow.com/questions/47837087/nginx-ingress-rewrite-target